### PR TITLE
Changing LIKE queries to ILIKE to allow for case insensitive searching

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::EventsController < ApplicationController
 		if params[:like] then
 			if params[:raw] then
 				# WILD CARD SEARCH
-				events = Event.where(["raw LIKE ?", "%#{query[:raw]}%"])
+				events = Event.where(["raw ILIKE ?", "%#{query[:raw]}%"])
 			elsif params[:detailed] then
 				# DETAILED SEARCH
 				details = JSON.parse params[:detailed]
@@ -35,14 +35,14 @@ class Api::V1::EventsController < ApplicationController
 						elsif key == "additional_arguments"
 							hash = JSON.parse value
 							hash.each do |k, v|
-								statement_array << "additional_arguments LIKE ?"
+								statement_array << "additional_arguments ILIKE ?"
 								value_array << "%\"#{k}\":\"#{v}\"%"
 
-								statement_array << "additional_arguments LIKE ?"
+								statement_array << "additional_arguments ILIKE ?"
 								value_array << "%\"#{k}\":#{v}%"
 							end
 						else
-							statement_array << "\"#{key}\" LIKE ?"
+							statement_array << "\"#{key}\" ILIKE ?"
 							value_array << "%#{value}%"
 						end
 					end


### PR DESCRIPTION
I've been caught out while copy/pasting email addresses and additional arguments not finding results because the source had a different case to how it had been passed to SendGrid in the first place.  Using ILIKE instead of LIKE seems to solve the problem (even if it is unique to POSTGRESQL, I'm not sure if that's a problem for this project or not)
