### PR TITLE
#29 - Event API search fix for type_id column

### DIFF
--- a/app/assets/javascripts/controllers/detailed_search_controller.coffee
+++ b/app/assets/javascripts/controllers/detailed_search_controller.coffee
@@ -116,7 +116,7 @@ EventKit.DetailedSearchController = Em.ArrayController.extend({
 		}
 		{
 		    name: "Type"
-		    id: "type"
+		    id: "type_id"
 		}
 		{
 		    name: "URL"

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -201,7 +201,7 @@ class Api::V1::EventsController < ApplicationController
 
 	private
 	def event_params(params)
-		params.require(:event).permit(:timestamp, :event, :email, :"smtp-id", :sg_event_id, :sg_message_id, :category, :newsletter, :response, :reason, :ip, :useragent, :attempt, :status, :type, :url, :additional_arguments, :event_post_timestamp, :raw, :asm_group_id)
+		params.require(:event).permit(:timestamp, :event, :email, :"smtp-id", :sg_event_id, :sg_message_id, :category, :newsletter, :response, :reason, :ip, :useragent, :attempt, :status, :type_id, :url, :additional_arguments, :event_post_timestamp, :raw, :asm_group_id)
 	end
 
 end


### PR DESCRIPTION
o Rename detailed search attribute id to type_id so the correct field name is used
o Rename 'type' event parameter to 'type_id' so the field is accepted by the controller